### PR TITLE
Fix player disconnect on empty vendor slot sync and item loss when selling to an empty vendor

### DIFF
--- a/common/src/main/java/dev/ithundxr/createnumismatics/content/vendor/VendorBlockEntity.java
+++ b/common/src/main/java/dev/ithundxr/createnumismatics/content/vendor/VendorBlockEntity.java
@@ -776,15 +776,16 @@ public class VendorBlockEntity extends SmartBlockEntity implements Trusted, Trus
         if (!matchesSellingItem(stack)) return;
         if (isCreativeVendor()) return;
 
+        int maxStackSize = getSellingItem().getMaxStackSize();
         for (int i = 0; i < items.size(); i++) {
             ItemStack item = items.get(i);
             if (item.isEmpty() || matchesSellingItem(item)) {
-                if (item.getCount() + stack.getCount() <= item.getMaxStackSize()) {
+                if (item.getCount() + stack.getCount() <= maxStackSize) {
                     items.set(i, getSellingItem().copyWithCount(item.getCount() + stack.getCount()));
                     return;
                 } else {
-                    int diff = item.getMaxStackSize() - item.getCount();
-                    items.set(i, getSellingItem().copyWithCount(item.getMaxStackSize()));
+                    int diff = maxStackSize - item.getCount();
+                    items.set(i, getSellingItem().copyWithCount(maxStackSize));
                     stack.shrink(diff);
                 }
             }

--- a/common/src/main/java/dev/ithundxr/createnumismatics/registry/packets/VendorContainerSetSlotPacket.java
+++ b/common/src/main/java/dev/ithundxr/createnumismatics/registry/packets/VendorContainerSetSlotPacket.java
@@ -16,7 +16,7 @@ public record VendorContainerSetSlotPacket(int containerId, int stateId, int slo
         ByteBufCodecs.BYTE, i -> (byte) i.containerId,
         ByteBufCodecs.VAR_INT, VendorContainerSetSlotPacket::stateId,
         ByteBufCodecs.SHORT, i -> (short) i.slot, 
-        ItemStack.STREAM_CODEC, VendorContainerSetSlotPacket::itemStack,
+        ItemStack.OPTIONAL_STREAM_CODEC, VendorContainerSetSlotPacket::itemStack,
         (containerId, stateId, slot, itemStack) -> new VendorContainerSetSlotPacket(containerId, stateId, slot, itemStack)
     );
 


### PR DESCRIPTION
## Bug 1: Players get kicked when a vendor slot becomes empty

`VendorContainerSetSlotPacket` used the strict `ItemStack.STREAM_CODEC`, which throws `Empty ItemStack not allowed` when encoding `ItemStack.EMPTY`. Whenever the vendor menu syncs a slot that was just cleared, the server fails to encode `numismatics:vendor_container_set_slot` and the player is disconnected:

```
io.netty.handler.codec.EncoderException: Failed to encode packet 'clientbound/minecraft'
Caused by: java.lang.RuntimeException: Failed encoding custom payload numismatics:vendor_container_set_slot: io.netty.handler.codec.EncoderException: Empty ItemStack not allowed
```

Fix: use `ItemStack.OPTIONAL_STREAM_CODEC`, the same codec already used by `VendorContainerSetContentPacket` and by vanilla's own `ClientboundContainerSetSlotPacket`.

## Bug 2: Items vanish when selling to an empty vendor (BUY mode)

`VendorBlockEntity.addBoughtItem` used `item.getMaxStackSize()` of the slot's current stack. For an empty slot that stack is `ItemStack.EMPTY`, whose max stack size is 0, so:

- the "fits in one slot" branch is never taken (`0 + count <= 0` is false),
- the overflow branch computes `diff = 0 - 0 = 0` and shrinks the incoming stack by 0.

The items are already removed from the player's hand but never inserted into the vendor. Once all 9 slots happen to be occupied, `getMaxStackSize()` returns real values and selling by stacks starts working — matching the reported behavior.

Fix: use `getSellingItem().getMaxStackSize()`, which is correct regardless of slot contents. (`hasSpace()` already did this correctly for empty slots.)

Both fixes verified by building the NeoForge jar and testing the affected interactions.